### PR TITLE
fix: cast Frame name (`i8`) to `::std::os::raw::c_char` since for ARM `::std::os::raw::c_char` is `u8`

### DIFF
--- a/tracy-gizmos/src/lib.rs
+++ b/tracy-gizmos/src/lib.rs
@@ -823,7 +823,7 @@ impl Drop for Frame {
 		// frame! macro, which ensures that contained pointer is
 		// correct.
 		unsafe {
-			sys::___tracy_emit_frame_mark_end(self.0);
+			sys::___tracy_emit_frame_mark_end(self.0.cast());
 		}
 	}
 }
@@ -947,7 +947,7 @@ pub mod details {
 
 	#[inline(always)]
 	pub unsafe fn discontinuous_frame(name: *const i8) -> Frame {
-		sys::___tracy_emit_frame_mark_start(name);
+		sys::___tracy_emit_frame_mark_start(name.cast());
 		Frame(name)
 	}
 


### PR DESCRIPTION
See [here](https://github.com/rust-lang/rust/blob/7278554d82fa474a4e8b5c67afb009e11e41a841/library/core/src/ffi/primitives.rs#L39-L131)

Otherwise you will get the following when compiling on EC2 `m6g.4xlarge` machine:
```
error[E0308]: mismatched types
   --> /home/ec2-user/.cargo/git/checkouts/tracy-gizmos-14ee5fe14315e605/9052de6/tracy-gizmos/src/lib.rs:826:38
    |
826 |             sys::___tracy_emit_frame_mark_end(self.0);
    |             --------------------------------- ^^^^^^ expected `*const u8`, found `*const i8`
    |             |
    |             arguments to this function are incorrect
    |
    = note: expected raw pointer `*const u8`
               found raw pointer `*const i8`
note: function defined here
   --> /home/ec2-user/.cargo/git/checkouts/tracy-gizmos-14ee5fe14315e605/9052de6/tracy-gizmos-sys/src/bindings.rs:229:12
    |
229 |     pub fn ___tracy_emit_frame_mark_end(name: *const ::std::os::raw::c_char);
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

error[E0308]: mismatched types
   --> /home/ec2-user/.cargo/git/checkouts/tracy-gizmos-14ee5fe14315e605/9052de6/tracy-gizmos/src/lib.rs:950:39
    |
950 |         sys::___tracy_emit_frame_mark_start(name);
    |         ----------------------------------- ^^^^ expected `*const u8`, found `*const i8`
    |         |
    |         arguments to this function are incorrect
    |
    = note: expected raw pointer `*const u8`
               found raw pointer `*const i8`
note: function defined here
   --> /home/ec2-user/.cargo/git/checkouts/tracy-gizmos-14ee5fe14315e605/9052de6/tracy-gizmos-sys/src/bindings.rs:228:12
    |
228 |     pub fn ___tracy_emit_frame_mark_start(name: *const ::std::os::raw::c_char);
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```