### PR TITLE
feat: Add intern plot

### DIFF
--- a/tracy-gizmos/src/plot.rs
+++ b/tracy-gizmos/src/plot.rs
@@ -40,7 +40,7 @@ macro_rules! plot {
 		}
 	};
 
-	($plot:ident, $value:expr) => {{
+	($plot:expr, $value:expr) => {{
 		// match works as `let .. in` and is required to properly
 		// manage lifetimes.
 		match $value {

--- a/tracy-gizmos/src/plot.rs
+++ b/tracy-gizmos/src/plot.rs
@@ -176,6 +176,10 @@ pub fn intern_plot_name(name: &str) -> &'static CStr {
         .get_or_init(|| Mutex::new(HashMap::new()))
         .lock()
         .unwrap();
+    if let Some(val) = map.get(name) {
+           return val;
+    }
+
     map.entry(name.into()).or_insert_with(|| {
         Box::leak(
             std::ffi::CString::new(name)

--- a/tracy-gizmos/src/plot.rs
+++ b/tracy-gizmos/src/plot.rs
@@ -164,6 +164,27 @@ impl_emit!(f64, ___tracy_emit_plot);
 impl_emit!(f32, ___tracy_emit_plot_float);
 impl_emit!(i64, ___tracy_emit_plot_int);
 
+/// Tracy stores the pointer as a uint64_t identifier and may dereference it
+/// later (via ServerQueryPlotName), so names must be effectively 'static.
+/// This interns to allocate at most once per unique name.
+#[doc(hidden)]
+pub fn intern_plot_name(name: &str) -> &'static CStr {
+    use std::collections::HashMap;
+    use std::sync::{Mutex, OnceLock};
+    static INTERNER: OnceLock<Mutex<HashMap<Box<str>, &'static CStr>>> = OnceLock::new();
+    let mut map = INTERNER
+        .get_or_init(|| Mutex::new(HashMap::new()))
+        .lock()
+        .unwrap();
+    map.entry(name.into()).or_insert_with(|| {
+        Box::leak(
+            std::ffi::CString::new(name)
+                .expect("plot name must not contain null bytes")
+                .into_boxed_c_str(),
+        )
+    })
+}
+
 /// A plot configuration, which controls the way plot will be
 /// displayed.
 #[derive(Debug, Clone, Copy)]

--- a/tracy-gizmos/src/plot.rs
+++ b/tracy-gizmos/src/plot.rs
@@ -180,13 +180,13 @@ pub fn intern_plot_name(name: &str) -> &'static CStr {
            return val;
     }
 
-    map.entry(name.into()).or_insert_with(|| {
-        Box::leak(
+    let cstring = Box::leak(
             std::ffi::CString::new(name)
                 .expect("plot name must not contain null bytes")
                 .into_boxed_c_str(),
-        )
-    })
+        );
+    map.insert(name.into(), cstring);
+    cstring
 }
 
 /// A plot configuration, which controls the way plot will be


### PR DESCRIPTION
This is required to support non-literal plot names, such as per-consumer
reservations tracing.

e.g. initialization:
```
tracy_plot: Plot::with_config(
    intern_plot_name(&name),
    PlotConfig { format: PlotFormat::Memory, style: PlotStyle::Staircase, ..Default::default() },
),
```

e.g. usage:
```
tracy_gizmos::plot!(consumer_state.tracy_plot, consumer_state.memory_usage as i64);
```
